### PR TITLE
Add profile collective.person:catalog 

### DIFF
--- a/news/9.feature
+++ b/news/9.feature
@@ -1,0 +1,1 @@
+Add profile collective.person:catalog that adds contact_email, contact_phone and contact_website as metadata to the catalog. @ericof

--- a/src/collective/person/profiles.zcml
+++ b/src/collective/person/profiles.zcml
@@ -26,7 +26,16 @@
       description="Example content for collective.person"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/demo"
-      pre_handler=".setuphandlers.demo.create_example_content"
+      post_handler=".setuphandlers.demo.create_example_content"
+      />
+
+  <genericsetup:registerProfile
+      name="catalog"
+      title="Person: Catalog contact metadata"
+      description="Implement catalog metadata columns for collective.person"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/catalog"
+      post_handler=".setuphandlers.catalog.reindex_persons"
       />
 
   <genericsetup:registerProfile

--- a/src/collective/person/profiles/catalog/catalog.xml
+++ b/src/collective/person/profiles/catalog/catalog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object name="portal_catalog">
+
+  <column value="contact_email" />
+  <column value="contact_phone" />
+  <column value="contact_website" />
+
+</object>

--- a/src/collective/person/profiles/catalog/metadata.xml
+++ b/src/collective/person/profiles/catalog/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <version>1000</version>
+</metadata>

--- a/src/collective/person/profiles/demo/metadata.xml
+++ b/src/collective/person/profiles/demo/metadata.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
   <version>1000</version>
+  <dependencies>
+    <dependency>profile-plone.volto:default</dependency>
+  </dependencies>
 </metadata>

--- a/src/collective/person/setuphandlers/catalog.py
+++ b/src/collective/person/setuphandlers/catalog.py
@@ -3,6 +3,6 @@ from Products.GenericSetup.tool import SetupTool
 
 
 def reindex_persons(context: SetupTool):
-    """Reindex all Person objects to update the index."""
-    idxs = ["sortable_title", "Title", "SearchableText", "object_provides"]
+    """Recatalog all person content to add metadata columns."""
+    idxs = ["contact_email", "contact_phone", "contact_website"]
     reindex_all_person_content(idxs)

--- a/src/collective/person/utils.py
+++ b/src/collective/person/utils.py
@@ -1,0 +1,14 @@
+from collective.person import logger
+from collective.person.behaviors.person import IPersonDataMarker
+from plone import api
+
+
+def reindex_all_person_content(idxs: list[str]):
+    """Recatalog Person content items."""
+    brains = api.content.find(object_provides=IPersonDataMarker)
+    total = len(brains)
+    logger.info(f"Will reindex {', '.join(idxs)} for {total} Person objects.")
+    for brain in brains:
+        obj = brain.getObject()
+        obj.reindexObject(idxs=idxs)
+    logger.info(f"Reindexed {total} Person objects.")

--- a/tests/behaviors/conftest.py
+++ b/tests/behaviors/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture()
+def additional_profiles() -> list[str]:
+    """List of additional profiles to apply on top of the default testing profile."""
+    return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,13 @@ def roles_vocab():
         ]
     }
 
+
 @pytest.fixture()
 def additional_profiles() -> list[str]:
     """List of additional profiles to apply on top of the default testing profile."""
-    return ["collective.person:demo", ]
+    return [
+        "collective.person:demo",
+    ]
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,18 @@ def roles_vocab():
         ]
     }
 
+@pytest.fixture()
+def additional_profiles() -> list[str]:
+    """List of additional profiles to apply on top of the default testing profile."""
+    return ["collective.person:demo", ]
+
 
 @pytest.fixture()
-def portal(integration, roles_vocab):
+def portal(integration, roles_vocab, additional_profiles):
     portal = integration["portal"]
     setup_tool = api.portal.get_tool("portal_setup")
-    setup_tool.runAllImportStepsFromProfile("collective.person:demo")
+    for profile in additional_profiles:
+        setup_tool.runAllImportStepsFromProfile(profile)
     with api.env.adopt_user(SITE_OWNER_NAME):
         # Set registry for roles
         api.portal.set_registry_record("person.roles", roles_vocab)

--- a/tests/indexing/conftest.py
+++ b/tests/indexing/conftest.py
@@ -1,0 +1,8 @@
+
+import pytest
+
+
+@pytest.fixture()
+def additional_profiles() -> list[str]:
+    """List of additional profiles to apply on top of the default testing profile."""
+    return ["collective.person:demo", "collective.person:catalog",]

--- a/tests/indexing/conftest.py
+++ b/tests/indexing/conftest.py
@@ -1,8 +1,10 @@
-
 import pytest
 
 
 @pytest.fixture()
 def additional_profiles() -> list[str]:
     """List of additional profiles to apply on top of the default testing profile."""
-    return ["collective.person:demo", "collective.person:catalog",]
+    return [
+        "collective.person:demo",
+        "collective.person:catalog",
+    ]

--- a/tests/indexing/test_catalog_metadata.py
+++ b/tests/indexing/test_catalog_metadata.py
@@ -1,0 +1,29 @@
+from collective.person.behaviors.person import IPersonDataMarker
+from plone import api
+
+import pytest
+
+
+class TestCatalogMetadata:
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, portal):
+        self.portal = portal
+
+
+    @pytest.mark.parametrize(
+        "query,column,expected",
+        [
+            ({"portal_type": "Person", "Title": "Elnor"}, "contact_email", "elnor@starfleet.space"),
+            ({"portal_type": "Person", "Title": "Elnor"}, "contact_phone", None),
+            ({"portal_type": "Person", "Title": "Elnor"}, "contact_website", "https://starfleet.space"),
+            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_email", "ortegas@starfleet.space"),
+            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_phone", "+99325421255"),
+            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_website", "https://starfleet.space"),
+        ]
+    )
+    def test_additional_metadata(self, query: dict, column: str, expected: str | None):
+        """Test title indexer."""
+        brains = api.content.find(**query)
+        assert len(brains) == 1
+        assert getattr(brains[0], column) == expected

--- a/tests/indexing/test_catalog_metadata.py
+++ b/tests/indexing/test_catalog_metadata.py
@@ -5,22 +5,40 @@ import pytest
 
 
 class TestCatalogMetadata:
-
     @pytest.fixture(autouse=True)
     def _setup(self, portal):
         self.portal = portal
 
-
     @pytest.mark.parametrize(
         "query,column,expected",
         [
-            ({"portal_type": "Person", "Title": "Elnor"}, "contact_email", "elnor@starfleet.space"),
+            (
+                {"portal_type": "Person", "Title": "Elnor"},
+                "contact_email",
+                "elnor@starfleet.space",
+            ),
             ({"portal_type": "Person", "Title": "Elnor"}, "contact_phone", None),
-            ({"portal_type": "Person", "Title": "Elnor"}, "contact_website", "https://starfleet.space"),
-            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_email", "ortegas@starfleet.space"),
-            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_phone", "+99325421255"),
-            ({"object_provides": IPersonDataMarker, "Title": "Ortegas"}, "contact_website", "https://starfleet.space"),
-        ]
+            (
+                {"portal_type": "Person", "Title": "Elnor"},
+                "contact_website",
+                "https://starfleet.space",
+            ),
+            (
+                {"object_provides": IPersonDataMarker, "Title": "Ortegas"},
+                "contact_email",
+                "ortegas@starfleet.space",
+            ),
+            (
+                {"object_provides": IPersonDataMarker, "Title": "Ortegas"},
+                "contact_phone",
+                "+99325421255",
+            ),
+            (
+                {"object_provides": IPersonDataMarker, "Title": "Ortegas"},
+                "contact_website",
+                "https://starfleet.space",
+            ),
+        ],
     )
     def test_additional_metadata(self, query: dict, column: str, expected: str | None):
         """Test title indexer."""


### PR DESCRIPTION
Adds contact_email, contact_phone and contact_website as metadata to the catalog ()

Closes #9